### PR TITLE
fix(bots): use 127.0.0.1 instead of localhost to avoid IPv6 resolutio…

### DIFF
--- a/apps/web/discord-bot.js
+++ b/apps/web/discord-bot.js
@@ -66,8 +66,8 @@ function sendToSkales(message, userId, username) {
             username,
         });
         const options = {
-            hostname: 'localhost',
-            port: 3000,
+            hostname: '127.0.0.1', // Use IPv4 to avoid IPv6 resolution issues,
+            port: process.env.SKALES_PORT || 3000,
             path: '/api/chat',
             method: 'POST',
             headers: { 'Content-Type': 'application/json', 'Content-Length': Buffer.byteLength(body) },

--- a/apps/web/telegram-bot.js
+++ b/apps/web/telegram-bot.js
@@ -24,7 +24,7 @@ const DATA_DIR = process.env.SKALES_DATA_DIR || path.join(os.homedir(), '.skales
 // Dynamic API base URL — reads the port Electron/Next.js is actually bound to.
 // SKALES_PORT is injected by telegram.ts when spawning this process.
 // Fallback to 3000 for backwards compatibility and standalone invocations.
-const API_BASE = `http://localhost:${process.env.SKALES_PORT || 3000}`;
+const API_BASE = `http://127.0.0.1:${process.env.SKALES_PORT || 3000}`;
 
 const TELEGRAM_FILE = path.join(DATA_DIR, 'integrations', 'telegram.json');
 const SETTINGS_FILE = path.join(DATA_DIR, 'settings.json');


### PR DESCRIPTION
…n issues

On some systems, Node.js resolves 'localhost' to IPv6 ::1, but the Next.js server only binds to IPv4 127.0.0.1. This causes 'connection refused' errors for Telegram and Discord bots.

Changes:
- telegram-bot.js: Use 127.0.0.1 explicitly for API_BASE
- discord-bot.js: Use 127.0.0.1 and respect SKALES_PORT env var
