### PR TITLE
Add timezone setting for desktop app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -189,3 +189,4 @@ temp/
  
 # Skills
 skills-lock.json
+.serena/

--- a/apps/web/src/app/settings/page.tsx
+++ b/apps/web/src/app/settings/page.tsx
@@ -50,6 +50,7 @@ import {
 } from '@/actions/backup';
 import { getUserTier, FEATURE_CONFIG, getFeatureTierLabel } from '@/lib/license';
 import { useTranslation, SUPPORTED_LOCALES } from '@/lib/i18n';
+import { timezoneGroups } from '@/lib/timezones';
 import {
     setAutonomousMode,
 } from '@/actions/autonomous';
@@ -564,9 +565,10 @@ export default function SettingsPage() {
         return 'general';
     });
 
-    // Desktop App — auto-launch + desktop buddy (Electron only)
+    // Desktop App — auto-launch + desktop buddy + timezone (Electron only)
     const [autoLaunch, setAutoLaunch] = useState(false);
     const [desktopBuddy, setDesktopBuddy] = useState(false);
+    const [timezone, setTimezone] = useState('');
     const isElectron = typeof window !== 'undefined' && !!(window as any).skales;
 
     // Buddy skins
@@ -598,7 +600,7 @@ export default function SettingsPage() {
         return () => clearInterval(interval);
     }, []);
 
-    // Load auto-launch + desktop-buddy state from Electron (no-op in browser)
+    // Load auto-launch + desktop-buddy + timezone state from Electron (no-op in browser)
     useEffect(() => {
         if (isElectron && (window as any).skales?.invoke) {
             (window as any).skales.invoke('get-auto-launch')
@@ -606,6 +608,9 @@ export default function SettingsPage() {
                 .catch(() => { /* not available */ });
             (window as any).skales.invoke('get-desktop-buddy')
                 .then((enabled: boolean) => setDesktopBuddy(enabled))
+                .catch(() => { /* not available */ });
+            (window as any).skales.invoke('get-timezone')
+                .then((tz: string) => setTimezone(tz || ''))
                 .catch(() => { /* not available */ });
         }
         // Fetch available skins from the API (works in both Electron and browser)
@@ -1977,6 +1982,39 @@ export default function SettingsPage() {
                                 >
                                     <span className={`pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out ${desktopBuddy ? 'translate-x-5' : 'translate-x-0'}`} />
                                 </button>
+                            </div>
+
+                            {/* Timezone selector */}
+                            <div className="mt-4 border-t pt-4" style={{ borderColor: 'var(--border)' }}>
+                                <div className="mb-2">
+                                    <p className="text-sm font-medium flex items-center gap-1.5" style={{ color: 'var(--text-primary)' }}>
+                                        🌐 Timezone
+                                    </p>
+                                    <p className="text-xs mt-0.5" style={{ color: 'var(--text-muted)' }}>
+                                        Auto-detected from your system. Select a timezone to override.
+                                    </p>
+                                </div>
+                                <select
+                                    value={timezone}
+                                    onChange={(e) => {
+                                        const value = e.target.value;
+                                        setTimezone(value);
+                                        (window as any).skales?.send('set-timezone', value);
+                                    }}
+                                    className="w-full px-3 py-2 rounded-lg text-sm bg-[var(--surface)] border"
+                                    style={{ borderColor: 'var(--border)', color: 'var(--text-primary)' }}
+                                >
+                                    <option value="">Select a timezone...</option>
+                                    {timezoneGroups.map((group) => (
+                                        <optgroup key={group.region} label={group.region}>
+                                            {group.timezones.map((tz) => (
+                                                <option key={tz.value} value={tz.value}>
+                                                    {tz.label}
+                                                </option>
+                                            ))}
+                                        </optgroup>
+                                    ))}
+                                </select>
                             </div>
 
                             {/* Buddy Skin selector — accordion, visible when buddy is ON */}

--- a/apps/web/src/lib/timezones.ts
+++ b/apps/web/src/lib/timezones.ts
@@ -1,0 +1,74 @@
+// Common IANA timezones for the settings dropdown
+// Grouped by region for easier navigation
+export const timezoneGroups = [
+  {
+    region: 'Americas',
+    timezones: [
+      { value: 'America/New_York', label: 'Eastern Time (US & Canada)' },
+      { value: 'America/Chicago', label: 'Central Time (US & Canada)' },
+      { value: 'America/Denver', label: 'Mountain Time (US & Canada)' },
+      { value: 'America/Los_Angeles', label: 'Pacific Time (US & Canada)' },
+      { value: 'America/Anchorage', label: 'Alaska' },
+      { value: 'Pacific/Honolulu', label: 'Hawaii' },
+      { value: 'America/Toronto', label: 'Toronto' },
+      { value: 'America/Vancouver', label: 'Vancouver' },
+      { value: 'America/Mexico_City', label: 'Mexico City' },
+      { value: 'America/Sao_Paulo', label: 'Sao Paulo' },
+      { value: 'America/Buenos_Aires', label: 'Buenos Aires' },
+    ]
+  },
+  {
+    region: 'Europe',
+    timezones: [
+      { value: 'Europe/London', label: 'London' },
+      { value: 'Europe/Paris', label: 'Paris' },
+      { value: 'Europe/Berlin', label: 'Berlin' },
+      { value: 'Europe/Madrid', label: 'Madrid' },
+      { value: 'Europe/Rome', label: 'Rome' },
+      { value: 'Europe/Amsterdam', label: 'Amsterdam' },
+      { value: 'Europe/Brussels', label: 'Brussels' },
+      { value: 'Europe/Vienna', label: 'Vienna' },
+      { value: 'Europe/Stockholm', label: 'Stockholm' },
+      { value: 'Europe/Warsaw', label: 'Warsaw' },
+      { value: 'Europe/Moscow', label: 'Moscow' },
+    ]
+  },
+  {
+    region: 'Asia',
+    timezones: [
+      { value: 'Asia/Tokyo', label: 'Tokyo' },
+      { value: 'Asia/Shanghai', label: 'Shanghai' },
+      { value: 'Asia/Hong_Kong', label: 'Hong Kong' },
+      { value: 'Asia/Singapore', label: 'Singapore' },
+      { value: 'Asia/Seoul', label: 'Seoul' },
+      { value: 'Asia/Dubai', label: 'Dubai' },
+      { value: 'Asia/Kolkata', label: 'India (Kolkata)' },
+      { value: 'Asia/Bangkok', label: 'Bangkok' },
+      { value: 'Asia/Jakarta', label: 'Jakarta' },
+    ]
+  },
+  {
+    region: 'Pacific',
+    timezones: [
+      { value: 'Australia/Sydney', label: 'Sydney' },
+      { value: 'Australia/Melbourne', label: 'Melbourne' },
+      { value: 'Australia/Brisbane', label: 'Brisbane' },
+      { value: 'Australia/Perth', label: 'Perth' },
+      { value: 'Pacific/Auckland', label: 'Auckland' },
+    ]
+  },
+  {
+    region: 'Other',
+    timezones: [
+      { value: 'UTC', label: 'UTC' },
+      { value: 'Africa/Cairo', label: 'Cairo' },
+      { value: 'Africa/Johannesburg', label: 'Johannesburg' },
+      { value: 'Africa/Lagos', label: 'Lagos' },
+    ]
+  }
+];
+
+// Flatten for use in select dropdown
+export const allTimezones = timezoneGroups.flatMap(group =>
+  group.timezones.map(tz => ({ ...tz, group: group.region }))
+);

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -1,5 +1,5 @@
 # electron-builder.yml
-# Skales v7.1.0 — Production Build Configuration
+# Skales v7.6.0 — Production Build Configuration
 # Docs: https://www.electron.build/configuration/configuration
 
 appId: app.skales.desktop
@@ -123,8 +123,8 @@ mac:
   # These keys are merged into the generated Info.plist inside the .app bundle.
   extendInfo:
     NSHumanReadableCopyright: "Copyright © 2026 Skales. All rights reserved."
-    CFBundleShortVersionString: "7.1.0"
-    CFBundleVersion: "7.1.0"
+    CFBundleShortVersionString: "7.6.0"
+    CFBundleVersion: "7.6.0"
     # Required for Login Items (auto-launch) via SMLoginItemSetEnabled / LSUIElement
     LSUIElement: false
     # Declare usage descriptions required by macOS privacy prompts

--- a/electron/main.js
+++ b/electron/main.js
@@ -6,6 +6,51 @@ const { spawn } = require('child_process');
 const net = require('net');
 const fs = require('fs');
 const path = require('path');
+
+// ─── Timezone Detection ───────────────────────────────────────────────────────
+// Detect system timezone: Linux/macOS from /etc/localtime, Windows via Intl API
+// Falls back to TZ env var, then UTC
+function detectSystemTimezone() {
+  // 1. Check existing TZ environment variable
+  if (process.env.TZ) {
+    console.log('[Skales] Timezone from TZ env:', process.env.TZ);
+    return process.env.TZ;
+  }
+
+  // 2. Read /etc/localtime on Linux and macOS
+  if (process.platform === 'linux' || process.platform === 'darwin') {
+    try {
+      const localtime = '/etc/localtime';
+      if (fs.existsSync(localtime)) {
+        const stats = fs.lstatSync(localtime);
+        if (stats.isSymbolicLink()) {
+          const target = fs.readlinkSync(localtime);
+          const match = target.match(/zoneinfo\/(.+)$/);
+          if (match) {
+            console.log('[Skales] Timezone from /etc/localtime:', match[1]);
+            return match[1];
+          }
+        } else {
+          console.log('[Skales] /etc/localtime is not a symlink');
+        }
+      }
+    } catch (e) {
+      console.warn('[Skales] Could not read /etc/localtime:', e.message);
+    }
+  }
+
+  // 3. Windows: use Intl API (works on all platforms, returns system timezone)
+  const intlTz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+  if (intlTz && intlTz !== 'UTC') {
+    console.log('[Skales] Timezone from Intl:', intlTz);
+    return intlTz;
+  }
+
+  // 4. Fallback to UTC
+  console.log('[Skales] Timezone fallback: UTC');
+  return 'UTC';
+}
+
 const { createTray } = require('./tray');
 const { setupUpdater } = require('./updater');
 
@@ -119,6 +164,22 @@ ipcMain.on('set-auto-launch', (_event, enabled) => {
   console.log(`[Skales] Auto-launch ${enabled ? 'enabled' : 'disabled'}.`);
 });
 
+// ─── Timezone IPC ───────────────────────────────────────────────────────────
+ipcMain.handle('get-timezone', async () => {
+  const settings = readSettings();
+  if (settings.timezone) return settings.timezone;
+  // detectedTimezone is set at app ready; if not yet set, detect now
+  if (!detectedTimezone) {
+    detectedTimezone = detectSystemTimezone();
+  }
+  return detectedTimezone;
+});
+
+ipcMain.on('set-timezone', (_event, timezone) => {
+  writeSettings({ timezone });
+  console.log('[Skales] Timezone set to:', timezone);
+});
+
 // ─── Export / Save-dialog IPC ─────────────────────────────────────────────────
 // Used by the Export Backup feature so it can save the ZIP to a user-chosen
 // location using a native save dialog — rather than relying on the browser's
@@ -181,6 +242,7 @@ let buddyWindow = null;
 let serverProcess = null;
 let serverReady = false;
 let desktopBuddyEnabled = false;  // loaded from disk below
+let detectedTimezone = undefined;  // set at app ready, or lazily if needed
 
 // ─── Splash Error ─────────────────────────────────────────────────────────────
 // Update the splash screen to show a red error state without closing it.
@@ -507,7 +569,12 @@ async function startServer() {
     // Next.js standalone server resolves to the standalone dir, not apps/web.
     SKALES_WEB_DIR: WEB_DIR,
     // Ensure the server can find native modules in extraResources
-    NODE_PATH: path.join(process.resourcesPath || '', 'apps', 'web', 'node_modules')
+    NODE_PATH: path.join(process.resourcesPath || '', 'apps', 'web', 'node_modules'),
+    // Propagate timezone to Next.js server
+    TZ: (() => {
+      const settings = readSettings();
+      return settings.timezone || detectedTimezone;
+    })()
   };
 
   // On Windows, hide the console window that would otherwise flash up when
@@ -717,6 +784,10 @@ function sendTelemetry(event, extra) {
 
 // ─── App Lifecycle ────────────────────────────────────────────────────────────
 app.on('ready', async () => {
+  // Detect system timezone on startup
+  detectedTimezone = detectSystemTimezone();
+  console.log('[Skales] Detected system timezone:', detectedTimezone);
+
   // Load persisted settings before anything else
   try { desktopBuddyEnabled = !!readSettings().desktopBuddy; } catch { desktopBuddyEnabled = false; }
   console.log('[Skales] Desktop Buddy enabled (persisted):', desktopBuddyEnabled);

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -39,7 +39,7 @@ contextBridge.exposeInMainWorld('skales', {
       'download-update', // confirm download of the available update
       'install-update',  // quitAndInstall — restart + apply downloaded update
       // ── Other ───────────────────────────────────────────────────────────
-      'set-auto-launch', 'relaunch-app', 'set-desktop-buddy', 'open-chat',
+      'set-auto-launch', 'relaunch-app', 'set-desktop-buddy', 'set-timezone', 'open-chat',
     ];
     if (allowed.includes(channel)) {
       ipcRenderer.send(channel, ...args);
@@ -50,7 +50,7 @@ contextBridge.exposeInMainWorld('skales', {
    * Send a message and await a reply from the main process.
    */
   invoke: (channel, ...args) => {
-    const allowed = ['get-auto-launch', 'show-save-dialog', 'copy-file', 'get-desktop-buddy', 'execute-skill'];
+    const allowed = ['get-auto-launch', 'show-save-dialog', 'copy-file', 'get-desktop-buddy', 'get-timezone', 'execute-skill'];
     if (!allowed.includes(channel)) return Promise.reject(new Error(`Channel '${channel}' not allowed`));
     return ipcRenderer.invoke(channel, ...args);
   },

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "skales",
-  "version": "7.1.0",
+  "version": "7.6.0",
   "description": "Skales - Your Local AI Agent",
-  "author": "Mario Simic",
+  "author": "Mario Simic <mario@skales.app>",
   "homepage": "https://skales.app",
   "main": "electron/main.js",
   "scripts": {


### PR DESCRIPTION
## Summary
- Adds system timezone detection on desktop app startup
- Adds timezone selector in the settings page (Electron only)
- Propagates timezone to Next.js server via TZ environment variable
- Updates version to v7.6.0

## Changes
- `.gitignore`: Added `.serena/` directory
- `apps/web/src/app/settings/page.tsx`: Added timezone selector UI
- `apps/web/src/lib/timezones.ts`: New file with timezone data grouped by region
- `electron/main.js`: Added timezone detection and IPC handlers
- `electron/preload.js`: Exposed timezone IPC channels
- `electron-builder.yml`: Updated version to 7.6.0
- `package.json`: Updated version to 7.6.0

## Test plan
- [ ] Test timezone detection on Linux
- [ ] Test timezone detection on macOS
- [ ] Test timezone detection on Windows
- [ ] Verify timezone selector appears in Electron desktop app
- [ ] Verify timezone persists after app restart

🤖 Generated with [Claude Code](https://claude.ai/claude-code)