### PR TITLE
Added translations of Buddy phrases into all 12 supported languages.

### DIFF
--- a/apps/web/src/actions/chat.ts
+++ b/apps/web/src/actions/chat.ts
@@ -2,6 +2,7 @@
 
 import path from 'path';
 import fs from 'fs';
+import { clearLocaleCache } from '@/lib/server-i18n';
 
 // ============================================================
 // Skales Chat Server Actions — v2.0
@@ -339,6 +340,9 @@ export async function saveAllSettings(newSettings: Partial<SkalesSettings>) {
                 : current.providers,
         };
         fs.writeFileSync(SETTINGS_FILE, JSON.stringify(merged, null, 2));
+        if (newSettings.locale !== undefined || newSettings.nativeLanguage !== undefined) {
+            clearLocaleCache();
+        }
         return { success: true, settings: merged };
     } catch (e: any) {
         return { success: false, error: e.message };

--- a/apps/web/src/app/bootstrap/page.tsx
+++ b/apps/web/src/app/bootstrap/page.tsx
@@ -21,7 +21,7 @@ const CLOUD_PROVIDERS = [
 
 export default function BootstrapPage() {
     const router = useRouter();
-    const { t, setLocale } = useTranslation();
+    const { t, setLocale, locale } = useTranslation();
     const [showLangPicker, setShowLangPicker] = useState(true); // shown before step 0
     const [step, setStep] = useState(0); // 0 = Security Disclaimer (mandatory)
     const [saving, setSaving] = useState(false);
@@ -196,8 +196,8 @@ export default function BootstrapPage() {
             // Safety mode
             await saveAllSettings({ safetyMode: safetyChoice } as any);
 
-            // Telemetry preference (opt-in only)
-            await saveAllSettings({ telemetry_enabled: formData.telemetryEnabled } as any);
+            // Telemetry preference (opt-in only) + UI language (for Desktop Buddy & server i18n)
+            await saveAllSettings({ telemetry_enabled: formData.telemetryEnabled, locale } as any);
 
             // Identity (completion sentinel — writes both soul.json and human.json)
             await completeBootstrap({
@@ -226,7 +226,7 @@ export default function BootstrapPage() {
         submitting.current = true;
         setSaving(true);
         try {
-            await saveAllSettings({ safetyMode: 'safe' } as any);
+            await saveAllSettings({ safetyMode: 'safe', locale } as any);
             await completeBootstrap({} as any);
             router.push('/chat');
         } finally {

--- a/apps/web/src/app/buddy/page.tsx
+++ b/apps/web/src/app/buddy/page.tsx
@@ -46,6 +46,7 @@
 
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { useTranslation } from '@/lib/i18n';
+import { normalizeUiLocale } from '@/lib/supported-locales';
 
 // ─── Utilities ────────────────────────────────────────────────────────────────
 
@@ -76,7 +77,7 @@ type FSM = 'intro' | 'idle' | 'action';
 
 export default function BuddyPage() {
 
-    const { t } = useTranslation();
+    const { t, setLocale } = useTranslation();
 
     // ── Double-buffer: two video slots ────────────────────────────────────────
     // Opacity is managed ONLY by direct DOM manipulation (not React state).
@@ -245,8 +246,23 @@ export default function BuddyPage() {
         fetch('/api/telemetry/ping?event=feature_used&feature=buddy').catch(() => {});
     }, []);
 
+    // When the user changes language in the main window, localStorage updates — the
+    // `storage` event fires in other windows (Desktop Buddy) so we stay in sync.
+    useEffect(() => {
+        const onStorage = (e: StorageEvent) => {
+            if (e.key === 'skales-locale' && e.newValue) {
+                setLocale(normalizeUiLocale(e.newValue));
+            }
+        };
+        window.addEventListener('storage', onStorage);
+        return () => window.removeEventListener('storage', onStorage);
+    }, [setLocale]);
+
     // When the response arrives the refs are updated and clipsReady is set to
     // true, which triggers the boot FSM useEffect below.
+    // Runs once on mount only: `setLocale` is called here to hydrate from
+    // settings, but it is intentionally omitted from deps so we never re-fetch
+    // clip lists when locale changes (clips are not language-specific).
     useEffect(() => {
         const loadClips = async () => {
             // Read active skin from settings; fall back to 'skales'
@@ -257,6 +273,9 @@ export default function BuddyPage() {
                     const s = await settingsRes.json();
                     if (typeof s?.buddy_skin === 'string' && /^[a-z0-9_-]+$/i.test(s.buddy_skin)) {
                         skin = s.buddy_skin;
+                    }
+                    if (typeof s?.locale === 'string') {
+                        setLocale(normalizeUiLocale(s.locale));
                     }
                 }
             } catch { /* non-fatal: use default */ }
@@ -279,6 +298,7 @@ export default function BuddyPage() {
         };
 
         loadClips();
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- mount-only; see comment above useEffect
     }, []);
 
     // ── Step 2: Boot FSM — runs once after clips are loaded ───────────────────
@@ -438,7 +458,7 @@ export default function BuddyPage() {
             const data = await res.json().catch(() => ({}));
 
             if (!res.ok) {
-                const errMsg = `Error ${res.status}: ${data.error ?? 'unknown'}`;
+                const errMsg = t('buddy.httpError', { status: res.status, detail: data.error ?? 'unknown' });
                 setBubble(errMsg);
                 setBubbleLong(false);
                 setBubbleIsError(true);
@@ -475,7 +495,7 @@ export default function BuddyPage() {
 
             // ── Tool result (auto-executed) or plain text ─────────────────────
             // Bug 28: strip think/reasoning XML before displaying in the buddy bubble
-            let reply = stripThinkingTags((data.content ?? '').trim() || 'No response.');
+            let reply = stripThinkingTags((data.content ?? '').trim() || t('buddy.noResponse'));
             const wasLong = data.wasLong === true || reply.length > 110;
             if (!data.wasLong && reply.length > 110) reply = reply.slice(0, 107) + '…';
 
@@ -546,7 +566,7 @@ export default function BuddyPage() {
                 const isSandbox = /sandbox|restricted|not allowed|permission|access denied/i.test(rawErr);
                 const errorMsg = isSandbox
                     ? t('buddy.sandboxRestricted')
-                    : (rawErr || (!res.ok ? `Error (${res.status})` : t('buddy.errorMessage')));
+                    : (rawErr || (!res.ok ? t('buddy.httpError', { status: res.status, detail: 'unknown' }) : t('buddy.errorMessage')));
                 setBubble(errorMsg);
                 setBubbleIsError(true);
                 bubbleTimer.current = setTimeout(() => { setBubble(null); setBubbleIsError(false); }, 10_000);

--- a/apps/web/src/app/settings/page.tsx
+++ b/apps/web/src/app/settings/page.tsx
@@ -50,6 +50,7 @@ import {
 } from '@/actions/backup';
 import { getUserTier, FEATURE_CONFIG, getFeatureTierLabel } from '@/lib/license';
 import { useTranslation, SUPPORTED_LOCALES } from '@/lib/i18n';
+import { normalizeUiLocale } from '@/lib/supported-locales';
 import {
     setAutonomousMode,
 } from '@/actions/autonomous';
@@ -723,6 +724,9 @@ export default function SettingsPage() {
             setActiveProvider(settings.activeProvider);
             setPersona(settings.persona || 'default');
             setNativeLanguage(settings.nativeLanguage || 'en');
+            if (settings.locale) {
+                setLocale(normalizeUiLocale(settings.locale));
+            }
 
             // Load Active Behavior settings
             if (settings.activeUserBehavior) {
@@ -1706,6 +1710,7 @@ export default function SettingsPage() {
                 persona,
                 systemPrompt: customPromptActive ? systemPrompt : undefined,
                 nativeLanguage,
+                locale,
                 providers,
                 activeUserBehavior: activeBehavior,
                 gifIntegration: gifConfig,

--- a/apps/web/src/lib/autonomous-runner.ts
+++ b/apps/web/src/lib/autonomous-runner.ts
@@ -17,6 +17,8 @@ import {
 } from '@/lib/agent-tasks';
 import { log } from '@/lib/autopilot-logger';
 import { dispatchSkill, parseSkillFromTask, detectCriticalAction } from '@/lib/skill-dispatcher';
+import { serverT } from '@/lib/server-i18n';
+import { normalizeUiLocale } from '@/lib/supported-locales';
 
 // ── Cron dedup map: cronId → last execution timestamp ─────────────────────────
 // Prevents the same cron job from firing twice within its own interval window.
@@ -497,12 +499,14 @@ async function tickFriendMode(settings: any): Promise<void> {
         const { buildContext } = await import('@/actions/identity');
         const identityCtx = await buildContext();
 
+        const uiLang = normalizeUiLocale(settings?.locale || settings?.nativeLanguage);
         const systemPrompt = [
             `You are Skales, a proactive AI companion sending a short check-in message to your user.`,
             identityCtx,
             ``,
             `RULES — READ CAREFULLY:`,
             `- Write EXACTLY ONE short message (1-3 sentences max).`,
+            `- Write the entire message in the language for UI locale "${uiLang}" (BCP-47). Do not use English unless "${uiLang}" is en.`,
             `- Be natural, warm, and varied — never send the same opener twice.`,
             `- DO NOT start with "How are you?" or "How was your day?" — these are boring.`,
             `- Instead: reference recent topics, share a quick insight, make a light joke, or suggest something useful.`,
@@ -719,7 +723,7 @@ async function tick(): Promise<void> {
             const preview = result.length > 80 ? result.slice(0, 77) + '…' : result;
             await routeNotification({
                 type: 'task-complete',
-                message: `Done: "${task.title}"\n${preview}`,
+                message: serverT('buddy.taskDoneBody', { title: task.title, preview }),
                 emoji: '✅',
                 priority: task.priority === 'high' ? 'high' : 'medium',
                 cooldownMinutes: 1, // task completions have minimal cooldown
@@ -729,7 +733,9 @@ async function tick(): Promise<void> {
             try {
                 const { pushBuddyNotification } = await import('@/lib/buddy-notify');
                 const preview = result.length > 80 ? result.slice(0, 77) + '…' : result;
-                pushBuddyNotification(`✅ Done: "${task.title}"\n${preview}`);
+                pushBuddyNotification(
+                    `✅ ${serverT('buddy.taskDoneBody', { title: task.title, preview })}`,
+                );
             } catch { /* non-fatal */ }
         }
 
@@ -766,17 +772,19 @@ async function tick(): Promise<void> {
                 const errPreview = errorMsg.length > 80 ? errorMsg.slice(0, 77) + '…' : errorMsg;
                 await routeNotification({
                     type: 'task-blocked',
-                    message: `Blocked: "${task.title}"\n${errPreview}`,
+                    message: serverT('buddy.taskBlockedBody', { title: task.title, preview: errPreview }),
                     emoji: '🚫',
                     priority: 'high', // blocked = needs attention, bypass quiet hours
                     cooldownMinutes: 1,
-                    action: { label: 'View Tasks', route: '/tasks' },
+                    action: { label: serverT('buddy.viewTasks'), route: '/tasks' },
                 });
             } catch {
                 try {
                     const { pushBuddyNotification } = await import('@/lib/buddy-notify');
                     const errPreview = errorMsg.length > 80 ? errorMsg.slice(0, 77) + '…' : errorMsg;
-                    pushBuddyNotification(`🚫 Blocked: "${task.title}"\n${errPreview}`);
+                    pushBuddyNotification(
+                        `🚫 ${serverT('buddy.taskBlockedBody', { title: task.title, preview: errPreview })}`,
+                    );
                 } catch { /* non-fatal */ }
             }
         } else {

--- a/apps/web/src/lib/buddy-intelligence.ts
+++ b/apps/web/src/lib/buddy-intelligence.ts
@@ -15,6 +15,7 @@
 import fs from 'fs';
 import path from 'path';
 import { DATA_DIR } from '@/lib/paths';
+import { serverT } from '@/lib/server-i18n';
 
 // ─── Types ───────────────────────────────────────────────────────
 
@@ -148,7 +149,14 @@ export async function decideBuddyAction(ctx: BuddyContext, settings: any): Promi
             ctx.nextMeeting.minutesUntilStart > 0
         ) {
             if (notificationTypes['meeting-reminder'] !== false) {
-                const msg = `⏰ Meeting starting in ${ctx.nextMeeting.minutesUntilStart} min: ${ctx.nextMeeting.title}${ctx.nextMeeting.location ? ` at ${ctx.nextMeeting.location}` : ''}`;
+                const locationPart = ctx.nextMeeting.location
+                    ? serverT('buddy.proactive.meetingLocationPart', { location: ctx.nextMeeting.location })
+                    : '';
+                const msg = serverT('buddy.proactive.meetingStarting', {
+                    minutes: ctx.nextMeeting.minutesUntilStart,
+                    title: ctx.nextMeeting.title,
+                    locationPart,
+                });
                 return {
                     type: 'meeting-reminder',
                     message: msg,
@@ -167,7 +175,10 @@ export async function decideBuddyAction(ctx: BuddyContext, settings: any): Promi
             ctx.nextMeeting.description
         ) {
             if (notificationTypes['meeting-prep'] !== false) {
-                const msg = `⏰ Prep for "${ctx.nextMeeting.title}" in ${ctx.nextMeeting.minutesUntilStart} min`;
+                const msg = serverT('buddy.proactive.meetingPrep', {
+                    title: ctx.nextMeeting.title,
+                    minutes: ctx.nextMeeting.minutesUntilStart,
+                });
                 return {
                     type: 'meeting-prep',
                     message: msg,
@@ -182,7 +193,7 @@ export async function decideBuddyAction(ctx: BuddyContext, settings: any): Promi
         // (Repurposing since there's no dueAt field)
         if (ctx.tasksCount.blocked > 0) {
             if (notificationTypes['overdue-tasks'] !== false) {
-                const msg = `You have ${ctx.tasksCount.blocked} blocked task${ctx.tasksCount.blocked > 1 ? 's' : ''}. Review them to get unstuck.`;
+                const msg = serverT('buddy.proactive.blockedTasks', { count: ctx.tasksCount.blocked });
                 return {
                     type: 'overdue-tasks',
                     message: msg,
@@ -196,7 +207,7 @@ export async function decideBuddyAction(ctx: BuddyContext, settings: any): Promi
         // Rule d: Unread emails > 3 → 'email-alert' (LOW)
         if (ctx.unreadEmails > 3) {
             if (notificationTypes['email-alert'] !== false) {
-                const msg = `📧 You have ${ctx.unreadEmails} pending emails`;
+                const msg = serverT('buddy.proactive.pendingEmails', { count: ctx.unreadEmails });
                 return {
                     type: 'email-alert',
                     message: msg,
@@ -210,7 +221,7 @@ export async function decideBuddyAction(ctx: BuddyContext, settings: any): Promi
         // Rule e: Completed tasks today >= 3 → 'eod-summary' (only 16:00-19:00)
         if (ctx.tasksCount.completedToday >= 3 && ctx.currentHour >= 16 && ctx.currentHour < 19) {
             if (notificationTypes['eod-summary'] !== false) {
-                const msg = `✅ Great work today! You completed ${ctx.tasksCount.completedToday} tasks.`;
+                const msg = serverT('buddy.proactive.eodSummary', { count: ctx.tasksCount.completedToday });
                 return {
                     type: 'eod-summary',
                     message: msg,
@@ -224,7 +235,10 @@ export async function decideBuddyAction(ctx: BuddyContext, settings: any): Promi
         // Rule f: Idle > 45 min and pending tasks > 0 → 'idle-checkin' (LOW)
         if (ctx.idleMinutes > 45 && ctx.tasksCount.pending > 0) {
             if (notificationTypes['idle-checkin'] !== false) {
-                const msg = `💤 You've been idle for ${ctx.idleMinutes} min. Got ${ctx.tasksCount.pending} pending task${ctx.tasksCount.pending > 1 ? 's' : ''}.`;
+                const msg = serverT('buddy.proactive.idleCheckin', {
+                    minutes: ctx.idleMinutes,
+                    count: ctx.tasksCount.pending,
+                });
                 return {
                     type: 'idle-checkin',
                     message: msg,
@@ -239,8 +253,8 @@ export async function decideBuddyAction(ctx: BuddyContext, settings: any): Promi
         if (ctx.currentHour >= 7 && ctx.currentHour < 9) {
             if (notificationTypes['morning-greeting'] !== false) {
                 const greeting = ctx.tasksCount.pending > 0
-                    ? `☀️ Good morning! You have ${ctx.tasksCount.pending} task${ctx.tasksCount.pending > 1 ? 's' : ''} today.`
-                    : '☀️ Good morning!';
+                    ? serverT('buddy.proactive.morningWithTasks', { count: ctx.tasksCount.pending })
+                    : serverT('buddy.proactive.morningSimple');
                 return {
                     type: 'morning-greeting',
                     message: greeting,

--- a/apps/web/src/lib/buddy-notify.ts
+++ b/apps/web/src/lib/buddy-notify.ts
@@ -13,6 +13,7 @@
 import fs   from 'fs';
 import path from 'path';
 import { DATA_DIR } from '@/lib/paths';
+import { serverT } from '@/lib/server-i18n';
 
 const QUEUE_FILE = path.join(DATA_DIR, 'buddy-queue.json');
 const MAX_QUEUE  = 20; // prevent unbounded growth if buddy window is closed
@@ -71,7 +72,7 @@ export function pushBuddyNotification(
         text.includes('SyntaxError:')
     );
     const cleanText = looksLikeRawError
-        ? "Oops.. something didn't work. Could you take a look?"
+        ? serverT('buddy.errorMessage')
         : text.slice(0, 300);
     const entry: BuddyNotification = {
         text: cleanText,
@@ -89,7 +90,7 @@ export function pushBuddyNotification(
 
 /** Push an error notification — shows friendly message + "Open Chat" button. */
 export function pushBuddyError(rawError?: string): void {
-    pushBuddyNotification(rawError || "Oops.. something didn't work. Could you take a look?", true);
+    pushBuddyNotification(rawError || serverT('buddy.errorMessage'), true);
 }
 
 /**

--- a/apps/web/src/lib/i18n.ts
+++ b/apps/web/src/lib/i18n.ts
@@ -20,6 +20,7 @@
 
 import { useState, useEffect, useCallback } from 'react';
 import en from '@/locales/en.json';
+import { UI_LOCALE_CODES, normalizeUiLocale } from '@/lib/supported-locales';
 
 // ─── Supported locales ────────────────────────────────────────────────────────
 
@@ -40,6 +41,8 @@ export const SUPPORTED_LOCALES: LocaleInfo[] = [
     { code: 'ko', name: '한국어',    flag: '🇰🇷' },
     { code: 'pt', name: 'Português', flag: '🇧🇷' },
 ];
+
+export { UI_LOCALE_CODES, normalizeUiLocale };
 
 // ─── Catalogue (lazy-loaded translation maps) ─────────────────────────────────
 
@@ -114,17 +117,15 @@ export function useTranslation() {
         const stored = typeof localStorage !== 'undefined'
             ? localStorage.getItem(STORAGE_KEY) ?? 'en'
             : 'en';
-        const valid = SUPPORTED_LOCALES.find(l => l.code === stored)?.code ?? 'en';
-        if (valid !== 'en') {
-            loadLocale(valid).then(m => {
-                setMap(m);
-                setLocaleState(valid);
-            });
-        }
+        const valid = normalizeUiLocale(SUPPORTED_LOCALES.find(l => l.code === stored)?.code ?? stored);
+        loadLocale(valid).then(m => {
+            setMap(m);
+            setLocaleState(valid);
+        });
     }, []);
 
     const setLocale = useCallback((code: string) => {
-        const valid = SUPPORTED_LOCALES.find(l => l.code === code)?.code ?? 'en';
+        const valid = normalizeUiLocale(SUPPORTED_LOCALES.find(l => l.code === code)?.code ?? code);
         loadLocale(valid).then(m => {
             setMap(m);
             setLocaleState(valid);

--- a/apps/web/src/lib/server-i18n.ts
+++ b/apps/web/src/lib/server-i18n.ts
@@ -12,6 +12,7 @@
 import fs from 'fs';
 import path from 'path';
 import { DATA_DIR } from './paths';
+import { normalizeUiLocale } from './supported-locales';
 
 const localeCache: Record<string, Record<string, any>> = {};
 
@@ -19,7 +20,7 @@ function getUserLocale(): string {
     try {
         const settingsPath = path.join(DATA_DIR, 'settings.json');
         const settings = JSON.parse(fs.readFileSync(settingsPath, 'utf-8'));
-        return settings.language || settings.locale || 'en';
+        return normalizeUiLocale(settings.locale || settings.nativeLanguage);
     } catch {
         return 'en';
     }

--- a/apps/web/src/lib/supported-locales.ts
+++ b/apps/web/src/lib/supported-locales.ts
@@ -1,0 +1,13 @@
+/**
+ * UI locale codes supported by Skales (shared by client i18n and server-i18n).
+ * Keep in sync with SUPPORTED_LOCALES in lib/i18n.ts.
+ */
+
+export const UI_LOCALE_CODES = ['en', 'de', 'es', 'fr', 'ru', 'zh', 'ja', 'ko', 'pt'] as const;
+
+export type UiLocaleCode = (typeof UI_LOCALE_CODES)[number];
+
+export function normalizeUiLocale(code: string | undefined | null): UiLocaleCode {
+    const c = String(code || 'en').toLowerCase().split('-')[0];
+    return (UI_LOCALE_CODES as readonly string[]).includes(c) ? (c as UiLocaleCode) : 'en';
+}

--- a/apps/web/src/locales/de.json
+++ b/apps/web/src/locales/de.json
@@ -846,7 +846,23 @@
         "resultSummary": "Erledigt! {{summary}}",
         "openChatDetails": "Chat für Details öffnen",
         "approvalNeeded": "Diese Aktion braucht deine Freigabe:",
-        "sandboxRestricted": "Dateizugriff eingeschränkt. Ändere die Sandbox-Einstellungen unter Einstellungen → Sicherheit oder verwende einen anderen Pfad."
+        "sandboxRestricted": "Dateizugriff eingeschränkt. Ändere die Sandbox-Einstellungen unter Einstellungen → Sicherheit oder verwende einen anderen Pfad.",
+        "noResponse": "Keine Antwort.",
+        "httpError": "Fehler {{status}}: {{detail}}",
+        "viewTasks": "Aufgaben anzeigen",
+        "taskDoneBody": "Erledigt: \"{{title}}\"\n{{preview}}",
+        "taskBlockedBody": "Blockiert: \"{{title}}\"\n{{preview}}",
+        "proactive": {
+            "meetingStarting": "Meeting beginnt in {{minutes}} Min.: {{title}}{{locationPart}}",
+            "meetingLocationPart": " bei {{location}}",
+            "meetingPrep": "Vorbereitung für „{{title}}“ in {{minutes}} Min.",
+            "blockedTasks": "Du hast {{count}} blockierte Aufgabe(n). Sieh sie dir an, um weiterzukommen.",
+            "pendingEmails": "Du hast {{count}} ausstehende E-Mails",
+            "eodSummary": "Stark heute! Du hast {{count}} Aufgaben erledigt.",
+            "idleCheckin": "Du warst {{minutes}} Min. inaktiv. Du hast {{count}} ausstehende Aufgabe(n).",
+            "morningWithTasks": "Guten Morgen! Du hast heute {{count}} Aufgabe(n).",
+            "morningSimple": "Guten Morgen!"
+        }
     },
     "tasks": {
         "title": "Aufgaben",

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -846,7 +846,23 @@
         "resultSummary": "Done! {{summary}}",
         "openChatDetails": "Open Chat for details",
         "approvalNeeded": "This action needs your OK:",
-        "sandboxRestricted": "File access restricted. Change sandbox settings in Settings → Security or use a different path."
+        "sandboxRestricted": "File access restricted. Change sandbox settings in Settings → Security or use a different path.",
+        "noResponse": "No response.",
+        "httpError": "Error {{status}}: {{detail}}",
+        "viewTasks": "View Tasks",
+        "taskDoneBody": "Done: \"{{title}}\"\n{{preview}}",
+        "taskBlockedBody": "Blocked: \"{{title}}\"\n{{preview}}",
+        "proactive": {
+            "meetingStarting": "Meeting starting in {{minutes}} min: {{title}}{{locationPart}}",
+            "meetingLocationPart": " at {{location}}",
+            "meetingPrep": "Prep for \"{{title}}\" in {{minutes}} min",
+            "blockedTasks": "You have {{count}} blocked task(s). Review them to get unstuck.",
+            "pendingEmails": "You have {{count}} pending emails",
+            "eodSummary": "Great work today! You completed {{count}} tasks.",
+            "idleCheckin": "You've been idle for {{minutes}} min. You have {{count}} pending task(s).",
+            "morningWithTasks": "Good morning! You have {{count}} task(s) today.",
+            "morningSimple": "Good morning!"
+        }
     },
     "tasks": {
         "title": "Tasks",

--- a/apps/web/src/locales/es.json
+++ b/apps/web/src/locales/es.json
@@ -846,7 +846,23 @@
         "resultSummary": "¡Listo! {{summary}}",
         "openChatDetails": "Abrir Chat para más detalles",
         "approvalNeeded": "Esta acción necesita tu aprobación:",
-        "sandboxRestricted": "Acceso a archivos restringido. Cambia la configuración del sandbox en Ajustes → Seguridad o usa otra ruta."
+        "sandboxRestricted": "Acceso a archivos restringido. Cambia la configuración del sandbox en Ajustes → Seguridad o usa otra ruta.",
+        "noResponse": "Sin respuesta.",
+        "httpError": "Error {{status}}: {{detail}}",
+        "viewTasks": "Ver tareas",
+        "taskDoneBody": "Hecho: \"{{title}}\"\n{{preview}}",
+        "taskBlockedBody": "Bloqueado: \"{{title}}\"\n{{preview}}",
+        "proactive": {
+            "meetingStarting": "La reunión empieza en {{minutes}} min: {{title}}{{locationPart}}",
+            "meetingLocationPart": " en {{location}}",
+            "meetingPrep": "Prepárate para \"{{title}}\" en {{minutes}} min",
+            "blockedTasks": "Tienes {{count}} tarea(s) bloqueada(s). Revísalas para desatascarte.",
+            "pendingEmails": "Tienes {{count}} correos pendientes",
+            "eodSummary": "¡Buen trabajo hoy! Completaste {{count}} tareas.",
+            "idleCheckin": "Llevas {{minutes}} min inactivo. Tienes {{count}} tarea(s) pendiente(s).",
+            "morningWithTasks": "¡Buenos días! Tienes {{count}} tarea(s) hoy.",
+            "morningSimple": "¡Buenos días!"
+        }
     },
     "tasks": {
         "title": "Tareas",

--- a/apps/web/src/locales/fr.json
+++ b/apps/web/src/locales/fr.json
@@ -846,7 +846,23 @@
         "resultSummary": "Fait ! {{summary}}",
         "openChatDetails": "Ouvrir le Chat pour les détails",
         "approvalNeeded": "Cette action nécessite ton accord :",
-        "sandboxRestricted": "Accès aux fichiers restreint. Modifiez les paramètres du bac à sable dans Paramètres → Sécurité ou utilisez un autre chemin."
+        "sandboxRestricted": "Accès aux fichiers restreint. Modifiez les paramètres du bac à sable dans Paramètres → Sécurité ou utilisez un autre chemin.",
+        "noResponse": "Pas de réponse.",
+        "httpError": "Erreur {{status}} : {{detail}}",
+        "viewTasks": "Voir les tâches",
+        "taskDoneBody": "Terminé : « {{title}} »\n{{preview}}",
+        "taskBlockedBody": "Bloqué : « {{title}} »\n{{preview}}",
+        "proactive": {
+            "meetingStarting": "Réunion dans {{minutes}} min : {{title}}{{locationPart}}",
+            "meetingLocationPart": " à {{location}}",
+            "meetingPrep": "Prépare « {{title}} » dans {{minutes}} min",
+            "blockedTasks": "Tu as {{count}} tâche(s) bloquée(s). Jette un œil pour débloquer la situation.",
+            "pendingEmails": "Tu as {{count}} e-mails en attente",
+            "eodSummary": "Beau travail aujourd’hui ! Tu as terminé {{count}} tâches.",
+            "idleCheckin": "Tu es inactif depuis {{minutes}} min. Tu as {{count}} tâche(s) en attente.",
+            "morningWithTasks": "Bonjour ! Tu as {{count}} tâche(s) aujourd’hui.",
+            "morningSimple": "Bonjour !"
+        }
     },
     "tasks": {
         "title": "Tâches",

--- a/apps/web/src/locales/ja.json
+++ b/apps/web/src/locales/ja.json
@@ -845,8 +845,24 @@
         "cancelled": "Cancelled",
         "resultSummary": "Done! {{summary}}",
         "openChatDetails": "Open Chat for details",
-        "approvalNeeded": "This action needs your OK:",
-        "sandboxRestricted": "ファイルアクセスが制限されています。設定 → セキュリティでサンドボックス設定を変更するか、別のパスを使用してください。"
+        "approvalNeeded": "この操作には確認が必要です：",
+        "sandboxRestricted": "ファイルアクセスが制限されています。設定 → セキュリティでサンドボックス設定を変更するか、別のパスを使用してください。",
+        "noResponse": "応答がありません。",
+        "httpError": "エラー {{status}}: {{detail}}",
+        "viewTasks": "タスクを見る",
+        "taskDoneBody": "完了: 「{{title}}」\n{{preview}}",
+        "taskBlockedBody": "ブロック中: 「{{title}}」\n{{preview}}",
+        "proactive": {
+            "meetingStarting": "{{minutes}}分後にミーティング: {{title}}{{locationPart}}",
+            "meetingLocationPart": "（{{location}}）",
+            "meetingPrep": "「{{title}}」の準備まであと{{minutes}}分",
+            "blockedTasks": "ブロックされたタスクが{{count}}件あります。確認して進めましょう。",
+            "pendingEmails": "未処理のメールが{{count}}件あります",
+            "eodSummary": "今日はお疲れ様でした！{{count}}件のタスクを完了しました。",
+            "idleCheckin": "{{minutes}}分間操作がありません。保留中のタスクが{{count}}件あります。",
+            "morningWithTasks": "おはようございます！今日は{{count}}件のタスクがあります。",
+            "morningSimple": "おはようございます！"
+        }
     },
     "tasks": {
         "title": "タスク",

--- a/apps/web/src/locales/ko.json
+++ b/apps/web/src/locales/ko.json
@@ -846,7 +846,23 @@
         "resultSummary": "완료! {{summary}}",
         "openChatDetails": "자세한 내용은 채팅 열기",
         "approvalNeeded": "이 작업에는 확인이 필요합니다:",
-        "sandboxRestricted": "파일 접근이 제한되었습니다. 설정 → 보안에서 샌드박스 설정을 변경하거나 다른 경로를 사용하세요."
+        "sandboxRestricted": "파일 접근이 제한되었습니다. 설정 → 보안에서 샌드박스 설정을 변경하거나 다른 경로를 사용하세요.",
+        "noResponse": "응답이 없습니다.",
+        "httpError": "오류 {{status}}: {{detail}}",
+        "viewTasks": "작업 보기",
+        "taskDoneBody": "완료: \"{{title}}\"\n{{preview}}",
+        "taskBlockedBody": "차단됨: \"{{title}}\"\n{{preview}}",
+        "proactive": {
+            "meetingStarting": "{{minutes}}분 후 회의: {{title}}{{locationPart}}",
+            "meetingLocationPart": " ({{location}})",
+            "meetingPrep": "{{minutes}}분 후 \"{{title}}\" 준비",
+            "blockedTasks": "차단된 작업이 {{count}}개 있습니다. 확인해 보세요.",
+            "pendingEmails": "처리 대기 중인 메일 {{count}}개",
+            "eodSummary": "오늘 수고하셨습니다! {{count}}개 작업을 완료했습니다.",
+            "idleCheckin": "{{minutes}}분 동안 비활성 상태입니다. 대기 중인 작업 {{count}}개.",
+            "morningWithTasks": "좋은 아침입니다! 오늘 {{count}}개 작업이 있습니다.",
+            "morningSimple": "좋은 아침입니다!"
+        }
     },
     "tasks": {
         "title": "작업",

--- a/apps/web/src/locales/pt.json
+++ b/apps/web/src/locales/pt.json
@@ -846,7 +846,23 @@
         "resultSummary": "Pronto! {{summary}}",
         "openChatDetails": "Abrir Chat para detalhes",
         "approvalNeeded": "Esta ação precisa da sua aprovação:",
-        "sandboxRestricted": "Acesso a arquivos restrito. Altere as configurações de sandbox em Configurações → Segurança ou use um caminho diferente."
+        "sandboxRestricted": "Acesso a arquivos restrito. Altere as configurações de sandbox em Configurações → Segurança ou use um caminho diferente.",
+        "noResponse": "Sem resposta.",
+        "httpError": "Erro {{status}}: {{detail}}",
+        "viewTasks": "Ver tarefas",
+        "taskDoneBody": "Concluído: \"{{title}}\"\n{{preview}}",
+        "taskBlockedBody": "Bloqueado: \"{{title}}\"\n{{preview}}",
+        "proactive": {
+            "meetingStarting": "Reunião em {{minutes}} min: {{title}}{{locationPart}}",
+            "meetingLocationPart": " em {{location}}",
+            "meetingPrep": "Prepare-se para \"{{title}}\" em {{minutes}} min",
+            "blockedTasks": "Você tem {{count}} tarefa(s) bloqueada(s). Revise para destravar.",
+            "pendingEmails": "Você tem {{count}} e-mails pendentes",
+            "eodSummary": "Ótimo trabalho hoje! Você concluiu {{count}} tarefas.",
+            "idleCheckin": "Você está inativo há {{minutes}} min. Há {{count}} tarefa(s) pendente(s).",
+            "morningWithTasks": "Bom dia! Você tem {{count}} tarefa(s) hoje.",
+            "morningSimple": "Bom dia!"
+        }
     },
     "tasks": {
         "title": "Tarefas",

--- a/apps/web/src/locales/ru.json
+++ b/apps/web/src/locales/ru.json
@@ -845,8 +845,24 @@
         "cancelled": "Cancelled",
         "resultSummary": "Done! {{summary}}",
         "openChatDetails": "Open Chat for details",
-        "approvalNeeded": "This action needs your OK:",
-        "sandboxRestricted": "Доступ к файлам ограничен. Измените настройки песочницы в Настройки → Безопасность или используйте другой путь."
+        "approvalNeeded": "Это действие требует вашего подтверждения:",
+        "sandboxRestricted": "Доступ к файлам ограничен. Измените настройки песочницы в Настройки → Безопасность или используйте другой путь.",
+        "noResponse": "Нет ответа.",
+        "httpError": "Ошибка {{status}}: {{detail}}",
+        "viewTasks": "Открыть задачи",
+        "taskDoneBody": "Готово: «{{title}}»\n{{preview}}",
+        "taskBlockedBody": "Заблокировано: «{{title}}»\n{{preview}}",
+        "proactive": {
+            "meetingStarting": "Встреча через {{minutes}} мин: {{title}}{{locationPart}}",
+            "meetingLocationPart": " в {{location}}",
+            "meetingPrep": "Подготовка к «{{title}}» через {{minutes}} мин",
+            "blockedTasks": "У вас {{count}} заблокированных задач(и). Просмотрите их, чтобы продвинуться.",
+            "pendingEmails": "У вас {{count}} непрочитанных писем",
+            "eodSummary": "Отличная работа сегодня! Вы завершили {{count}} задач(и).",
+            "idleCheckin": "Вы неактивны {{minutes}} мин. У вас {{count}} ожидающих задач(и).",
+            "morningWithTasks": "Доброе утро! У вас сегодня {{count}} задач(и).",
+            "morningSimple": "Доброе утро!"
+        }
     },
     "tasks": {
         "title": "Задачи",

--- a/apps/web/src/locales/zh.json
+++ b/apps/web/src/locales/zh.json
@@ -845,8 +845,24 @@
         "cancelled": "Cancelled",
         "resultSummary": "Done! {{summary}}",
         "openChatDetails": "Open Chat for details",
-        "approvalNeeded": "This action needs your OK:",
-        "sandboxRestricted": "文件访问受限。请在设置 → 安全中更改沙盒设置，或使用其他路径。"
+        "approvalNeeded": "此操作需要您确认：",
+        "sandboxRestricted": "文件访问受限。请在设置 → 安全中更改沙盒设置，或使用其他路径。",
+        "noResponse": "暂无回复。",
+        "httpError": "错误 {{status}}：{{detail}}",
+        "viewTasks": "查看任务",
+        "taskDoneBody": "已完成：「{{title}}」\n{{preview}}",
+        "taskBlockedBody": "已阻塞：「{{title}}」\n{{preview}}",
+        "proactive": {
+            "meetingStarting": "{{minutes}} 分钟后会议开始：{{title}}{{locationPart}}",
+            "meetingLocationPart": "，地点 {{location}}",
+            "meetingPrep": "{{minutes}} 分钟后准备「{{title}}」",
+            "blockedTasks": "您有 {{count}} 个被阻塞的任务。请查看以继续推进。",
+            "pendingEmails": "您有 {{count}} 封待处理邮件",
+            "eodSummary": "今天做得很好！您完成了 {{count}} 个任务。",
+            "idleCheckin": "您已闲置 {{minutes}} 分钟。有 {{count}} 个待处理任务。",
+            "morningWithTasks": "早上好！您今天有 {{count}} 个任务。",
+            "morningSimple": "早上好！"
+        }
     },
     "tasks": {
         "title": "任务",


### PR DESCRIPTION
##What does this PR do?
#56 Fix Desktop Buddy and proactive notifications respecting the UI language

Summary :
Desktop Buddy and related bubbles stayed effectively English because the UI locale mostly lived in localStorage while server-side code read settings.json, locale resolution was wrong, and several strings were hardcoded. This PR persists locale, fixes server-i18n resolution, routes proactive / task / error copy through serverT, and syncs the Buddy window from settings, localStorage (cross-window storage events), and bootstrap/settings saves.
What changed
settings.json / locale: Save locale from Settings and Bootstrap so server helpers and /api/settings/get agree with the UI.
server-i18n: Resolve locale via normalizeUiLocale(settings.locale || settings.nativeLanguage) (replacing the invalid settings.language lookup). Clear the locale cache when locale / nativeLanguage is saved.
Buddy page: Hydrate setLocale from /api/settings/get, listen for skales-locale storage events (other Electron windows), localize HTTP / empty-reply strings, keep clip loading mount-only ([] + documented exhaustive-deps exception).
buddy-intelligence.ts, buddy-notify.ts, autonomous-runner.ts: Replace hardcoded English with serverT('buddy.*') (proactive phrases, task done/blocked, “View tasks”, sanitized errors). Friend Mode prompt instructs the model to use the UI locale.
lib/supported-locales.ts: Shared codes + normalizeUiLocale; i18n.ts uses it and always loads the active catalogue on mount.
Locales: Added buddy.noResponse, buddy.httpError, buddy.viewTasks, buddy.task*", buddy.proactive.* to all 9 existing JSON locale files (project SUPPORTED_LOCALES; not 12 until more locales exist).
How to test
Set a non-English UI language, Save settings, confirm settings.json contains locale.
Open Desktop Buddy: placeholder, errors, and bubbles should match the language; change language in the main window and confirm Buddy updates (storage sync).
Trigger Buddy Intelligence or autopilot task completion / blocked notifications and confirm bubble text matches the locale.
Notes
Translations cover the nine shipped UI languages; aligning with an “12 languages” roadmap would mean new locales/*.json + SUPPORTED_LOCALES entries in a follow-up.