### PR TITLE
Fix recursive snapshotting and nested file context for Lio iteration

### DIFF
--- a/apps/web/src/app/api/code/build/route.ts
+++ b/apps/web/src/app/api/code/build/route.ts
@@ -3,6 +3,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import path from 'path';
 import fs from 'fs';
 import { getLioConfig, getProject, saveProject, callLlmSimple } from '@/actions/code-builder';
+import { listProjectContextFiles } from '@/lib/lio-project-files';
 
 // ─── Build API — streams step-by-step build progress ─────────
 
@@ -239,12 +240,12 @@ function buildStepContext(project: any, stepIndex: number, chatMessage?: string)
     // Gather existing files for context
     const existingFiles: string[] = [];
     try {
-        const files = fs.readdirSync(project.projectDir);
-        for (const f of files) {
-            if (f === 'project.json') continue;
+        const files = listProjectContextFiles(project.projectDir, { maxFiles: 12 });
+        for (const file of files) {
+            if (file.relativePath === 'project.json') continue;
             try {
-                const content = fs.readFileSync(path.join(project.projectDir, f), 'utf-8');
-                existingFiles.push(`\n--- ${f} ---\n${content.slice(0, 2000)}`);
+                const content = fs.readFileSync(file.absolutePath, 'utf-8');
+                existingFiles.push(`\n--- ${file.relativePath} ---\n${content.slice(0, 2000)}`);
             } catch { /* skip */ }
         }
     } catch { /* dir not ready */ }

--- a/apps/web/src/app/api/code/plan/route.ts
+++ b/apps/web/src/app/api/code/plan/route.ts
@@ -3,6 +3,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import fs from 'fs';
 import path from 'path';
 import { getLioConfig, callLlmSimple, createProject, getProject, saveProject, type LioPlan } from '@/actions/code-builder';
+import { listProjectContextFiles } from '@/lib/lio-project-files';
 
 // ─── Planning API — streams Architect + Reviewer discussion ──
 
@@ -134,21 +135,17 @@ export async function POST(req: NextRequest) {
                     const dir = existingProjectDir || project.projectDir;
                     try {
                         if (fs.existsSync(dir)) {
-                            const files = fs.readdirSync(dir).filter(f =>
-                                !f.startsWith('_') && !f.startsWith('.') &&
-                                (f.endsWith('.html') || f.endsWith('.css') || f.endsWith('.js') ||
-                                 f.endsWith('.ts') || f.endsWith('.tsx') || f.endsWith('.json') ||
-                                 f.endsWith('.py') || f.endsWith('.md'))
-                            );
+                            const files = listProjectContextFiles(dir, { maxFiles: 8 })
+                                .filter(file => file.relativePath !== 'project.json');
                             if (files.length > 0) {
-                                const snippets = files.slice(0, 8).map(f => {
+                                const snippets = files.map(file => {
                                     try {
-                                        const content = fs.readFileSync(path.join(dir, f), 'utf-8');
+                                        const content = fs.readFileSync(file.absolutePath, 'utf-8');
                                         const preview = content.length > 600 ? content.slice(0, 600) + '\n... (truncated)' : content;
-                                        return `### ${f}\n\`\`\`\n${preview}\n\`\`\``;
-                                    } catch { return `### ${f}\n(could not read)`; }
+                                        return `### ${file.relativePath}\n\`\`\`\n${preview}\n\`\`\``;
+                                    } catch { return `### ${file.relativePath}\n(could not read)`; }
                                 });
-                                existingFilesContext = `\n\n## Existing project files (${files.length} total):\n${snippets.join('\n\n')}`;
+                                existingFilesContext = `\n\n## Existing project files (showing ${files.length}):\n${snippets.join('\n\n')}`;
                             }
                         }
                     } catch { /* non-fatal */ }

--- a/apps/web/src/app/api/code/snapshot/route.ts
+++ b/apps/web/src/app/api/code/snapshot/route.ts
@@ -2,6 +2,7 @@ export const dynamic = 'force-dynamic';
 import { NextRequest, NextResponse } from 'next/server';
 import fs from 'fs';
 import path from 'path';
+import { copyProjectSnapshot } from '@/lib/lio-project-files';
 
 /**
  * POST /api/code/snapshot
@@ -19,17 +20,7 @@ export async function POST(req: NextRequest) {
         const backupDir = path.join(projectDir, '_backups', String(timestamp));
         fs.mkdirSync(backupDir, { recursive: true });
 
-        // Copy all non-backup, non-hidden files
-        const files = fs.readdirSync(projectDir).filter(f => !f.startsWith('_') && !f.startsWith('.'));
-        for (const file of files) {
-            try {
-                const src = path.join(projectDir, file);
-                const dst = path.join(backupDir, file);
-                if (fs.statSync(src).isFile()) {
-                    fs.copyFileSync(src, dst);
-                }
-            } catch { /* skip unreadable files */ }
-        }
+        const files = copyProjectSnapshot(projectDir, backupDir);
 
         // Write snapshot metadata
         fs.writeFileSync(path.join(backupDir, '.snapshot-meta.json'), JSON.stringify({

--- a/apps/web/src/lib/lio-project-files.ts
+++ b/apps/web/src/lib/lio-project-files.ts
@@ -1,0 +1,123 @@
+import fs from 'fs';
+import path from 'path';
+
+export interface ProjectFileEntry {
+    relativePath: string;
+    absolutePath: string;
+}
+
+interface ListProjectContextFilesOptions {
+    maxFiles?: number;
+    allowedExtensions?: string[];
+}
+
+const DEFAULT_ALLOWED_EXTENSIONS = new Set([
+    '.html', '.css', '.js', '.ts', '.tsx', '.json', '.py', '.md',
+]);
+
+const SKIP_DIRS = new Set([
+    '_backups',
+    '.git',
+    'node_modules',
+    '.next',
+    'dist',
+    'build',
+    'coverage',
+]);
+
+function shouldSkipDir(dirName: string): boolean {
+    return dirName.startsWith('.') || SKIP_DIRS.has(dirName);
+}
+
+function shouldIncludeFile(fileName: string, allowedExtensions: Set<string>): boolean {
+    if (fileName.startsWith('.')) return false;
+    return allowedExtensions.has(path.extname(fileName).toLowerCase());
+}
+
+function compareDirents(a: fs.Dirent, b: fs.Dirent): number {
+    if (a.isDirectory() && !b.isDirectory()) return -1;
+    if (!a.isDirectory() && b.isDirectory()) return 1;
+    return a.name.localeCompare(b.name);
+}
+
+function walkProjectFiles(
+    rootDir: string,
+    currentDir: string,
+    allowedExtensions: Set<string>,
+    maxFiles: number,
+    results: ProjectFileEntry[]
+) {
+    if (results.length >= maxFiles) return;
+
+    const entries = fs.readdirSync(currentDir, { withFileTypes: true }).sort(compareDirents);
+    for (const entry of entries) {
+        if (results.length >= maxFiles) return;
+
+        const absolutePath = path.join(currentDir, entry.name);
+        const relativePath = path.relative(rootDir, absolutePath);
+
+        if (entry.isDirectory()) {
+            if (shouldSkipDir(entry.name)) continue;
+            walkProjectFiles(rootDir, absolutePath, allowedExtensions, maxFiles, results);
+            continue;
+        }
+
+        if (!entry.isFile()) continue;
+        if (!shouldIncludeFile(entry.name, allowedExtensions)) continue;
+
+        results.push({ relativePath, absolutePath });
+    }
+}
+
+export function listProjectContextFiles(
+    projectDir: string,
+    options: ListProjectContextFilesOptions = {}
+): ProjectFileEntry[] {
+    if (!fs.existsSync(projectDir)) return [];
+
+    const allowedExtensions = new Set(
+        (options.allowedExtensions || [...DEFAULT_ALLOWED_EXTENSIONS]).map(ext => ext.toLowerCase())
+    );
+    const maxFiles = options.maxFiles ?? 8;
+    const results: ProjectFileEntry[] = [];
+
+    walkProjectFiles(projectDir, projectDir, allowedExtensions, maxFiles, results);
+    return results.sort((a, b) => a.relativePath.localeCompare(b.relativePath));
+}
+
+export function copyProjectSnapshot(projectDir: string, backupDir: string): ProjectFileEntry[] {
+    if (!fs.existsSync(projectDir)) return [];
+
+    const copied: ProjectFileEntry[] = [];
+    const stack: string[] = [projectDir];
+
+    while (stack.length > 0) {
+        const currentDir = stack.pop()!;
+        const entries = fs.readdirSync(currentDir, { withFileTypes: true }).sort(compareDirents);
+
+        for (const entry of entries) {
+            const absolutePath = path.join(currentDir, entry.name);
+            const relativePath = path.relative(projectDir, absolutePath);
+
+            if (entry.isDirectory()) {
+                if (shouldSkipDir(entry.name)) continue;
+                stack.push(absolutePath);
+                continue;
+            }
+
+            if (!entry.isFile()) continue;
+            if (entry.name.startsWith('.')) continue;
+
+            try {
+                const destination = path.join(backupDir, relativePath);
+                fs.mkdirSync(path.dirname(destination), { recursive: true });
+                fs.copyFileSync(absolutePath, destination);
+                copied.push({ relativePath, absolutePath });
+            } catch {
+                // Snapshotting is best-effort; skip unreadable files.
+            }
+        }
+    }
+
+    return copied.sort((a, b) => a.relativePath.localeCompare(b.relativePath));
+}

--- a/apps/web/test/lio-project-files.test.mjs
+++ b/apps/web/test/lio-project-files.test.mjs
@@ -1,0 +1,70 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import {
+    copyProjectSnapshot,
+    listProjectContextFiles,
+} from '../src/lib/lio-project-files.ts';
+
+function makeTempDir() {
+    return fs.mkdtempSync(path.join(os.tmpdir(), 'skales-lio-test-'));
+}
+
+function writeFile(rootDir, relativePath, content) {
+    const filePath = path.join(rootDir, relativePath);
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, content, 'utf-8');
+}
+
+test('copyProjectSnapshot copies nested source files and skips generated folders', () => {
+    const projectDir = makeTempDir();
+    const backupDir = path.join(projectDir, '_backups', String(Date.now()));
+
+    writeFile(projectDir, 'index.html', '<!doctype html>');
+    writeFile(projectDir, 'src/app/page.tsx', 'export default function Page() { return null; }');
+    writeFile(projectDir, 'components/header.tsx', 'export function Header() { return null; }');
+    writeFile(projectDir, 'public/logo.svg', '<svg></svg>');
+    writeFile(projectDir, '_backups/old/index.html', 'old');
+    writeFile(projectDir, '.next/server/app.js', 'compiled');
+    writeFile(projectDir, 'node_modules/pkg/index.js', 'dependency');
+    writeFile(projectDir, '.env', 'SECRET=1');
+
+    const copied = copyProjectSnapshot(projectDir, backupDir);
+
+    assert.equal(copied.length, 4);
+    assert.deepEqual(
+        copied.map(entry => entry.relativePath).sort(),
+        ['components/header.tsx', 'index.html', 'public/logo.svg', 'src/app/page.tsx']
+    );
+
+    assert.ok(fs.existsSync(path.join(backupDir, 'src/app/page.tsx')));
+    assert.ok(fs.existsSync(path.join(backupDir, 'components/header.tsx')));
+    assert.ok(fs.existsSync(path.join(backupDir, 'public/logo.svg')));
+    assert.ok(!fs.existsSync(path.join(backupDir, '_backups/old/index.html')));
+    assert.ok(!fs.existsSync(path.join(backupDir, '.next/server/app.js')));
+    assert.ok(!fs.existsSync(path.join(backupDir, 'node_modules/pkg/index.js')));
+    assert.ok(!fs.existsSync(path.join(backupDir, '.env')));
+});
+
+test('listProjectContextFiles discovers nested project files with relative paths', () => {
+    const projectDir = makeTempDir();
+
+    writeFile(projectDir, 'src/app/page.tsx', 'export default function Page() { return null; }');
+    writeFile(projectDir, 'src/components/button.tsx', 'export const Button = () => null;');
+    writeFile(projectDir, 'README.md', '# Demo');
+    writeFile(projectDir, '_backups/old/page.tsx', 'stale');
+    writeFile(projectDir, 'dist/bundle.js', 'compiled');
+
+    const files = listProjectContextFiles(projectDir, {
+        maxFiles: 10,
+        allowedExtensions: ['.tsx', '.md'],
+    });
+
+    assert.deepEqual(
+        files.map(entry => entry.relativePath).sort(),
+        ['README.md', 'src/app/page.tsx', 'src/components/button.tsx']
+    );
+});


### PR DESCRIPTION
## Summary
- add a shared helper for recursively discovering Lio project files
- make iteration snapshots back up nested project files instead of only top-level files
- include nested project files in planning/build context so iteration works on real multi-folder apps
- add regression tests for recursive snapshotting and nested context discovery

## Problem
Lio's iteration flow only looked at top-level files when creating snapshots and when building context for replanning/building. That breaks the workflow for realistic projects with `src/`, `app/`, `components/`, or other nested directories.

## Changes
- introduced `listProjectContextFiles()` and `copyProjectSnapshot()` in `apps/web/src/lib/lio-project-files.ts`
- updated `/api/code/snapshot` to use recursive snapshotting
- updated `/api/code/plan` to read nested project files for iteration context
- updated `/api/code/build` to include nested project files in builder context
- filtered out internal `project.json` from Lio planning context

## Verification
- `node --experimental-strip-types --test apps/web/test/lio-project-files.test.mjs`

## Notes
- `npm run lint` in `apps/web` currently triggers Next.js ESLint setup interactively in this repository, so it was not usable as a non-interactive verification step
- `npx tsc --noEmit` reports existing unrelated TypeScript errors elsewhere in the repo
