### PR TITLE
Pass built-in agent system prompts through the orchestrator

### DIFF
--- a/apps/web/src/actions/agents.ts
+++ b/apps/web/src/actions/agents.ts
@@ -5,6 +5,7 @@ import path from 'path';
 import crypto from 'crypto';
 
 import { DATA_DIR } from '@/lib/paths';
+import { buildAgentExecutionRequest } from '@/lib/agent-execution-request';
 const AGENTS_DIR = path.join(DATA_DIR, 'agents');
 const DEFINITIONS_DIR = path.join(AGENTS_DIR, 'definitions');
 const EXECUTIONS_DIR = path.join(AGENTS_DIR, 'executions');
@@ -180,13 +181,9 @@ export async function executeAgent(agentId: string, task: string): Promise<Agent
         execution.logs.push({ timestamp: Date.now(), message: 'Processing task with AI...', level: 'info' });
         fs.writeFileSync(execPath, JSON.stringify(execution, null, 2));
 
-        // Build a combined prompt using the agent's persona + the task
-        const agentPrompt = `[Agent: ${agent.name}]\n[System: ${agent.systemPrompt}]\n\nTask: ${task}`;
+        const agentRequest = buildAgentExecutionRequest(agent, task);
 
-        const result = await processMessageWithTools(agentPrompt, [], {
-            model: agent.model,
-            provider: agent.provider as any,
-        });
+        const result = await processMessageWithTools(agentRequest.message, [], agentRequest.options);
 
         execution.logs.push({ timestamp: Date.now(), message: `Completed via ${result.provider}/${result.model}`, level: 'info' });
         result.toolResults.forEach(tr => {

--- a/apps/web/src/actions/orchestrator.ts
+++ b/apps/web/src/actions/orchestrator.ts
@@ -5323,6 +5323,7 @@ export async function processMessageWithTools(
         sessionId?: string;
         provider?: Provider;
         model?: string;
+        systemPrompt?: string;
         confirmedToolCalls?: string[]; // Tool call IDs that user confirmed
         /** Optional callback fired on each ReAct step — used by Autopilot Live Execution view */
         onStep?: (step: { type: 'thinking' | 'tool_call' | 'tool_result'; content: string; toolName?: string }) => void;

--- a/apps/web/src/lib/agent-execution-request.ts
+++ b/apps/web/src/lib/agent-execution-request.ts
@@ -1,0 +1,28 @@
+import type { Provider } from '@/actions/chat';
+
+type AgentExecutionInput = {
+    name: string;
+    systemPrompt: string;
+    provider?: Provider;
+    model?: string;
+};
+
+type AgentExecutionRequest = {
+    message: string;
+    options: {
+        provider?: Provider;
+        model?: string;
+        systemPrompt: string;
+    };
+};
+
+export function buildAgentExecutionRequest(agent: AgentExecutionInput, task: string): AgentExecutionRequest {
+    return {
+        message: task,
+        options: {
+            provider: agent.provider,
+            model: agent.model,
+            systemPrompt: agent.systemPrompt,
+        },
+    };
+}

--- a/apps/web/test/agents-system-prompt.test.mjs
+++ b/apps/web/test/agents-system-prompt.test.mjs
@@ -1,0 +1,18 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { buildAgentExecutionRequest } from '../src/lib/agent-execution-request.ts';
+
+test('buildAgentExecutionRequest keeps task as user message and passes agent system prompt separately', () => {
+    const request = buildAgentExecutionRequest({
+        name: 'Code Assistant',
+        systemPrompt: 'You are an expert software engineer.',
+        provider: 'openrouter',
+        model: 'openai/gpt-4o-mini',
+    }, 'Fix the failing tests');
+
+    assert.equal(request.message, 'Fix the failing tests');
+    assert.equal(request.options.systemPrompt, 'You are an expert software engineer.');
+    assert.equal(request.options.provider, 'openrouter');
+    assert.equal(request.options.model, 'openai/gpt-4o-mini');
+});


### PR DESCRIPTION
## Summary
- pass built-in agent `systemPrompt` as a real orchestrator system prompt override
- stop embedding the built-in agent system prompt into the user task message
- add a regression test for built-in agent execution request construction

## Problem
Built-in agents currently execute by formatting the agent system prompt into the user message payload:

```text
[Agent: ...]
[System: ...]

Task: ...
```

That means the built-in agent persona is treated like user content instead of a real system prompt override, even though the orchestrator already supports `systemPrompt` in its internal decision path.

## Changes
- introduced `buildAgentExecutionRequest()` to construct the built-in agent execution payload
- updated `executeAgent()` to pass the task as the user message and `agent.systemPrompt` via `options.systemPrompt`
- updated the exported `processMessageWithTools()` options type to include `systemPrompt`
- added a regression test covering the new request shape

## Verification
- `node --experimental-strip-types --test apps/web/test/agents-system-prompt.test.mjs`

## Notes
- the commit author uses a GitHub `noreply` address to avoid exposing a personal email in public commit metadata
