### PR TITLE
feat(provider): add Qiniu provider support

### DIFF
--- a/apps/web/src/actions/autopilot.ts
+++ b/apps/web/src/actions/autopilot.ts
@@ -226,6 +226,7 @@ async function callLLM(settings: any, systemPrompt: string, userMessage: string)
         deepseek:   'https://api.deepseek.com/v1/chat/completions',
         xai:        'https://api.x.ai/v1/chat/completions',
         together:   'https://api.together.xyz/v1/chat/completions',
+        qiniu:      'https://api.qnaigc.com/v1/chat/completions',
         ollama:     (provCfg.baseUrl ?? 'http://localhost:11434/v1') + '/chat/completions',
     };
     const url = endpoints[provider] ?? endpoints.openrouter;

--- a/apps/web/src/actions/capabilities.ts
+++ b/apps/web/src/actions/capabilities.ts
@@ -295,6 +295,17 @@ export async function rebuildCapabilities(): Promise<void> {
         if (secrets.hasXAI) configuredProviders.push('xAI (Grok)');
         if (secrets.hasOpenRouter) configuredProviders.push('OpenRouter');
 
+        try {
+            const settingsPath = path.join(DATA_DIR, 'settings.json');
+            if (fs.existsSync(settingsPath)) {
+                const st = JSON.parse(fs.readFileSync(settingsPath, 'utf-8'));
+                const qn = st.providers?.qiniu;
+                if (qn?.apiKey && String(qn.apiKey).trim() && !configuredProviders.includes('Qiniu')) {
+                    configuredProviders.push('Qiniu');
+                }
+            }
+        } catch { /* ignore */ }
+
         // Build skill entries
         const skills: Record<string, {
             name: string; enabled: boolean; configured: boolean;

--- a/apps/web/src/actions/chat.ts
+++ b/apps/web/src/actions/chat.ts
@@ -23,7 +23,7 @@ function ensureDirs() {
 
 // ─── Types ───────────────────────────────────────────────────
 
-export type Provider = 'openrouter' | 'openai' | 'anthropic' | 'google' | 'ollama' | 'groq' | 'mistral' | 'deepseek' | 'xai' | 'together' | 'custom';
+export type Provider = 'openrouter' | 'openai' | 'anthropic' | 'google' | 'ollama' | 'groq' | 'mistral' | 'deepseek' | 'xai' | 'together' | 'qiniu' | 'custom';
 
 
 export interface ProviderConfig {
@@ -243,6 +243,12 @@ const DEFAULT_SETTINGS: SkalesSettings = {
             apiKey: '',
             baseUrl: 'https://api.together.xyz/v1',
             model: 'meta-llama/Llama-3-70b-chat-hf',
+            enabled: false,
+        },
+        qiniu: {
+            apiKey: '',
+            baseUrl: 'https://api.qnaigc.com/v1',
+            model: 'deepseek-v3',
             enabled: false,
         },
         custom: {

--- a/apps/web/src/actions/code-builder.ts
+++ b/apps/web/src/actions/code-builder.ts
@@ -251,6 +251,7 @@ export async function callLlmSimple(
         if (provider === 'together') return 'https://api.together.xyz/v1';
         if (provider === 'deepseek') return 'https://api.deepseek.com/v1';
         if (provider === 'xai') return 'https://api.x.ai/v1';
+        if (provider === 'qiniu') return 'https://api.qnaigc.com/v1';
         // FIX C: standardise to localhost (127.0.0.1 can cause CORS issues on some setups)
         if (provider === 'ollama') return 'http://localhost:11434/v1';
         return 'https://openrouter.ai/api/v1';

--- a/apps/web/src/actions/orchestrator.ts
+++ b/apps/web/src/actions/orchestrator.ts
@@ -4836,6 +4836,7 @@ export async function agentDecide(
         else if (provider === 'groq') providerConfig.model = 'llama-3.3-70b-versatile';
         else if (provider === 'openrouter') providerConfig.model = 'openai/gpt-4o-mini';
         else if (provider === 'ollama') providerConfig.model = 'llama3';
+        else if (provider === 'qiniu') providerConfig.model = 'deepseek-v3';
     }
 
     // Vision model routing:

--- a/apps/web/src/app/agents/page.tsx
+++ b/apps/web/src/app/agents/page.tsx
@@ -26,6 +26,10 @@ const PROVIDER_MODELS: Record<string, { value: string; label: string }[]> = {
         { value: 'gemini-2.0-flash', label: 'Gemini 2.0 Flash' },
         { value: 'gemini-1.5-flash', label: 'Gemini 1.5 Flash' },
     ],
+    qiniu: [
+        { value: 'deepseek-v3', label: 'DeepSeek V3' },
+        { value: 'gemini-2.5-flash', label: 'Gemini 2.5 Flash' },
+    ],
     ollama: [
         { value: 'llama3.2', label: 'Llama 3.2' },
         { value: 'mistral', label: 'Mistral 7B' },
@@ -397,6 +401,7 @@ export default function AgentsPage() {
                                         <option value="openai">{t('agents.providers.openai')}</option>
                                         <option value="anthropic">{t('agents.providers.anthropic')}</option>
                                         <option value="google">{t('agents.providers.google')}</option>
+                                        <option value="qiniu">{t('agents.providers.qiniu')}</option>
                                         <option value="ollama">{t('agents.providers.ollama')}</option>
                                     </select>
                                 </div>

--- a/apps/web/src/app/bootstrap/page.tsx
+++ b/apps/web/src/app/bootstrap/page.tsx
@@ -17,6 +17,7 @@ const CLOUD_PROVIDERS = [
     { id: 'deepseek',   name: 'DeepSeek',   placeholder: 'sk-...' },
     { id: 'xai',        name: 'xAI (Grok)', placeholder: 'xai-...' },
     { id: 'together',   name: 'Together AI', placeholder: 'key...' },
+    { id: 'qiniu',      name: 'Qiniu',       placeholder: 'API key...' },
 ];
 
 export default function BootstrapPage() {
@@ -111,6 +112,17 @@ export default function BootstrapPage() {
         }
         if (provider === 'together') {
             return ['meta-llama/Llama-3.3-70B-Instruct-Turbo', 'Qwen/Qwen2.5-72B-Instruct-Turbo', 'mistralai/Mixtral-8x22B-Instruct-v0.1'];
+        }
+        if (provider === 'qiniu') {
+            try {
+                const res = await fetch('https://api.qnaigc.com/v1/models', {
+                    headers: { 'Authorization': `Bearer ${apiKey}` },
+                });
+                const data = await res.json();
+                const ids = (data.data || []).map((m: any) => m.id).filter(Boolean);
+                if (ids.length) return ids.sort();
+            } catch { /* ignore */ }
+            return ['deepseek-v3', 'gemini-2.5-flash'];
         }
         return [];
     }

--- a/apps/web/src/app/custom-skills/page.tsx
+++ b/apps/web/src/app/custom-skills/page.tsx
@@ -55,6 +55,7 @@ const PROVIDERS = [
     { value: 'deepseek',   label: 'DeepSeek'      },
     { value: 'xai',        label: 'xAI / Grok'    },
     { value: 'together',   label: 'Together AI'   },
+    { value: 'qiniu',      label: 'Qiniu'          },
     { value: 'ollama',     label: 'Ollama (Local)' },
     { value: 'google',     label: 'Google AI'     },
 ];

--- a/apps/web/src/app/group-chat/settings/page.tsx
+++ b/apps/web/src/app/group-chat/settings/page.tsx
@@ -32,6 +32,7 @@ const KNOWN_PROVIDERS = [
     { id: 'deepseek', label: 'DeepSeek' },
     { id: 'xai', label: 'xAI (Grok)' },
     { id: 'together', label: 'Together AI' },
+    { id: 'qiniu', label: 'Qiniu' },
     { id: 'ollama', label: 'Ollama (local)' },
 ];
 

--- a/apps/web/src/app/settings/page.tsx
+++ b/apps/web/src/app/settings/page.tsx
@@ -88,6 +88,7 @@ const PROVIDER_CONFIG: { id: Provider; label: string; icon: string; desc: string
     { id: 'deepseek', label: 'DeepSeek', icon: '🐋', desc: 'DeepSeek V3, R1 - ultra-affordable, strong reasoning', color: '#4d9de0', needsKey: true },
     { id: 'xai', label: 'xAI / Grok', icon: '🌌', desc: 'Grok 2 - real-time knowledge, sharp reasoning', color: '#9b5de5', needsKey: true },
     { id: 'together', label: 'Together AI', icon: '🤝', desc: 'Llama 3, Mixtral, DBRX & 100+ open models - affordable inference', color: '#6366f1', needsKey: true },
+    { id: 'qiniu', label: 'Qiniu', icon: '☁️', desc: 'OpenAI-compatible gateway — DeepSeek, Gemini, and more', color: '#00a870', needsKey: true },
 ];
 
 
@@ -168,6 +169,10 @@ const PROVIDER_MODELS: Record<Provider, { value: string; label: string }[]> = {
         { value: 'Qwen/Qwen2.5-72B-Instruct-Turbo', label: 'Qwen 2.5 72B' },
         { value: 'deepseek-ai/deepseek-r1', label: 'DeepSeek R1 (Reasoning)' },
     ],
+    qiniu: [
+        { value: 'deepseek-v3', label: 'DeepSeek V3 (recommended)' },
+        { value: 'gemini-2.5-flash', label: 'Gemini 2.5 Flash' },
+    ],
     // Custom endpoint — no predefined models; populated dynamically via "Fetch Models"
     custom: [],
 };
@@ -196,7 +201,7 @@ export default function SettingsPage() {
     const [nativeLanguage, setNativeLanguage] = useState('en');
     const [apiKeys, setApiKeys] = useState<Record<Provider, string>>({
         openrouter: '', openai: '', anthropic: '', google: '', ollama: 'ollama', groq: '',
-        mistral: '', deepseek: '', xai: '', together: '', custom: '',
+        mistral: '', deepseek: '', xai: '', together: '', qiniu: '', custom: '',
     });
     const [models, setModels] = useState<Record<Provider, string>>({
         openrouter: 'openai/gpt-3.5-turbo',
@@ -209,6 +214,7 @@ export default function SettingsPage() {
         deepseek: 'deepseek-chat',
         xai: 'grok-2-latest',
         together: 'meta-llama/Llama-3-70b-chat-hf',
+        qiniu: 'deepseek-v3',
         custom: '',
     });
 
@@ -979,6 +985,19 @@ export default function SettingsPage() {
                 models = (data.data || [])
                     .map((m: any) => ({ id: m.id, name: m.name || m.id }))
                     .sort((a: any, b: any) => a.name.localeCompare(b.name));
+            } else if (providerId === 'qiniu') {
+                const res = await fetch('https://api.qnaigc.com/v1/models', {
+                    headers: { 'Authorization': `Bearer ${key}` },
+                    signal: AbortSignal.timeout(10000),
+                });
+                if (!res.ok) throw new Error(`HTTP ${res.status}`);
+                const data = await res.json();
+                models = (data.data || [])
+                    .map((m: any) => ({ id: m.id, name: m.id }))
+                    .sort((a: any, b: any) => a.id.localeCompare(b.id));
+                if (models.length === 0) {
+                    models = [{ id: 'deepseek-v3', name: 'deepseek-v3' }];
+                }
             }
 
             if (models.length === 0) throw new Error('No models returned');
@@ -2574,7 +2593,7 @@ export default function SettingsPage() {
                                     <span className="text-base">🔧</span>
                                     <span>More LLM Providers</span>
                                     <span className="text-[10px] px-2 py-0.5 rounded-full font-medium" style={{ background: 'var(--surface-light)', color: 'var(--text-muted)' }}>
-                                        OpenAI · Anthropic · Google · Groq · Mistral · DeepSeek · xAI
+                                        OpenAI · Anthropic · Google · Groq · Mistral · DeepSeek · xAI · Qiniu
                                     </span>
                                 </div>
                                 <ChevronDown size={16} style={{ transform: moreLLMsOpen ? 'rotate(180deg)' : 'none', transition: 'transform 0.2s', color: 'var(--text-muted)' }} />
@@ -2687,6 +2706,44 @@ export default function SettingsPage() {
                                                 {provider.id === 'xai' && (
                                                     <div className="mt-3 p-3 rounded-xl text-[11px]" style={{ background: 'rgba(155,93,229,0.06)', border: '1px solid rgba(155,93,229,0.2)', color: 'var(--text-muted)' }}>
                                                         🌌 Real-time knowledge via X/Twitter data. Get a key at <a href="https://console.x.ai" target="_blank" rel="noopener noreferrer" className="text-purple-400 underline">console.x.ai</a>.
+                                                    </div>
+                                                )}
+                                                {provider.id === 'qiniu' && (
+                                                    <div className="mt-3 space-y-2">
+                                                        <div className="p-3 rounded-xl text-[11px]" style={{ background: 'rgba(0,168,112,0.06)', border: '1px solid rgba(0,168,112,0.2)', color: 'var(--text-muted)' }}>
+                                                            OpenAI-compatible chat API. Keys are available from the Qiniu console; you can also set <code className="text-[10px]">QINIU_API_KEY</code> in the environment as a fallback.
+                                                        </div>
+                                                        <div className="p-3 rounded-xl" style={{ background: 'var(--surface)', border: '1px solid var(--border)' }}>
+                                                            <div className="flex items-center justify-between mb-1">
+                                                                <span className="text-[11px] font-bold" style={{ color: 'var(--text-primary)' }}>
+                                                                    <RotateCcw size={11} className="inline mr-1" />Fetch available models
+                                                                </span>
+                                                                <button
+                                                                    type="button"
+                                                                    onClick={() => fetchProviderModels('qiniu')}
+                                                                    disabled={fetchingModels.qiniu || !apiKeys.qiniu}
+                                                                    className="px-2.5 py-1 rounded-lg text-[10px] font-bold transition-all flex items-center gap-1 bg-lime-500/10 text-lime-500 hover:bg-lime-500/20 disabled:opacity-40"
+                                                                >
+                                                                    {fetchingModels.qiniu ? <Loader2 size={10} className="animate-spin" /> : <RotateCcw size={10} />}
+                                                                    Fetch
+                                                                </button>
+                                                            </div>
+                                                            {fetchedModels.qiniu?.length > 0 && (
+                                                                <select
+                                                                    value={models.qiniu}
+                                                                    onChange={e => setModels(prev => ({ ...prev, qiniu: e.target.value }))}
+                                                                    className="w-full p-2 rounded-lg text-xs outline-none transition-all focus:ring-1 focus:ring-lime-500 appearance-none cursor-pointer mt-1"
+                                                                    style={{ background: 'var(--background)', border: '1px solid var(--border)', color: 'var(--text-primary)' }}
+                                                                >
+                                                                    {fetchedModels.qiniu.map(m => (
+                                                                        <option key={m.id} value={m.id}>{m.name || m.id}</option>
+                                                                    ))}
+                                                                </select>
+                                                            )}
+                                                            {fetchModelError.qiniu && (
+                                                                <p className="text-[10px] mt-1 text-red-400">{fetchModelError.qiniu}</p>
+                                                            )}
+                                                        </div>
                                                     </div>
                                                 )}
                                                 <button onClick={() => handleTest(provider.id)} disabled={isTesting}

--- a/apps/web/src/data/builtin-skills/quoty.js
+++ b/apps/web/src/data/builtin-skills/quoty.js
@@ -45,6 +45,7 @@ const ENDPOINTS = {
   xai:        'https://api.x.ai/v1/chat/completions',
   together:   'https://api.together.xyz/v1/chat/completions',
   google:     'https://generativelanguage.googleapis.com/v1beta/openai/chat/completions',
+  qiniu:      'https://api.qnaigc.com/v1/chat/completions',
 };
 
 // Themes for variety
@@ -93,7 +94,7 @@ module.exports = {
         + `{"quote": "your quote here", "author": "Author Name", "theme": "${theme}"}`;
 
       // Try each configured provider until one works
-      const providerOrder = ['openrouter', 'openai', 'groq', 'google', 'mistral', 'deepseek', 'xai', 'together'];
+      const providerOrder = ['openrouter', 'openai', 'groq', 'google', 'mistral', 'deepseek', 'xai', 'together', 'qiniu'];
       let lastProviderError = '';
 
       for (const provId of providerOrder) {
@@ -110,6 +111,7 @@ module.exports = {
           || (provId === 'google'     ? 'gemini-2.0-flash'    : undefined)
           || (provId === 'mistral'    ? 'mistral-small-latest' : undefined)
           || (provId === 'deepseek'   ? 'deepseek-chat'       : undefined)
+          || (provId === 'qiniu'      ? 'deepseek-v3'         : undefined)
           || 'default';
 
         const headers = {

--- a/apps/web/src/lib/autonomous-runner.ts
+++ b/apps/web/src/lib/autonomous-runner.ts
@@ -240,6 +240,7 @@ async function _callLlmForTask(task: AgentTask, settings: any): Promise<string> 
             openrouter: 'https://openrouter.ai/api/v1/chat/completions',
             openai:     'https://api.openai.com/v1/chat/completions',
             groq:       'https://api.groq.com/openai/v1/chat/completions',
+            qiniu:      'https://api.qnaigc.com/v1/chat/completions',
         };
         const ep = endpointMap[provider] ?? 'https://openrouter.ai/api/v1/chat/completions';
 

--- a/apps/web/src/lib/skill-ai.ts
+++ b/apps/web/src/lib/skill-ai.ts
@@ -147,6 +147,7 @@ export async function callLLM(
         deepseek:   'https://api.deepseek.com/v1/chat/completions',
         xai:        'https://api.x.ai/v1/chat/completions',
         together:   'https://api.together.xyz/v1/chat/completions',
+        qiniu:      'https://api.qnaigc.com/v1/chat/completions',
         ollama:     `${baseUrl || 'http://localhost:11434/v1'}/chat/completions`,
         google:     'https://generativelanguage.googleapis.com/v1beta/openai/chat/completions',
     };

--- a/apps/web/src/lib/skill-dispatcher.ts
+++ b/apps/web/src/lib/skill-dispatcher.ts
@@ -243,6 +243,7 @@ export async function callLLMDirect(settings: any, systemPrompt: string, userMsg
         deepseek:   'https://api.deepseek.com/v1/chat/completions',
         xai:        'https://api.x.ai/v1/chat/completions',
         together:   'https://api.together.xyz/v1/chat/completions',
+        qiniu:      'https://api.qnaigc.com/v1/chat/completions',
     }[provider as string] ?? 'https://openrouter.ai/api/v1/chat/completions';
 
     const res = await fetch(url, {

--- a/apps/web/src/locales/de.json
+++ b/apps/web/src/locales/de.json
@@ -1040,6 +1040,7 @@
             "anthropic": "Anthropic",
             "google": "Google",
             "ollama": "Ollama (Lokal)",
+            "qiniu": "Qiniu",
             "custom": "Benutzerdefiniert (OpenAI-kompatibel)"
         },
         "defaultModel": "Standardmodell",

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -1040,6 +1040,7 @@
             "anthropic": "Anthropic",
             "google": "Google",
             "ollama": "Ollama (Local)",
+            "qiniu": "Qiniu",
             "custom": "Custom (OpenAI-compatible)"
         },
         "defaultModel": "Default Model",

--- a/apps/web/src/locales/es.json
+++ b/apps/web/src/locales/es.json
@@ -1040,6 +1040,7 @@
             "anthropic": "Anthropic",
             "google": "Google",
             "ollama": "Ollama (Local)",
+            "qiniu": "Qiniu",
             "custom": "Personalizado (compatible con OpenAI)"
         },
         "defaultModel": "Modelo predeterminado",

--- a/apps/web/src/locales/fr.json
+++ b/apps/web/src/locales/fr.json
@@ -1040,6 +1040,7 @@
             "anthropic": "Anthropic",
             "google": "Google",
             "ollama": "Ollama (Local)",
+            "qiniu": "Qiniu",
             "custom": "Personnalisé (compatible OpenAI)"
         },
         "defaultModel": "Modèle par défaut",

--- a/apps/web/src/locales/ja.json
+++ b/apps/web/src/locales/ja.json
@@ -1040,6 +1040,7 @@
             "anthropic": "Anthropic",
             "google": "Google",
             "ollama": "Ollama (Local)",
+            "qiniu": "Qiniu",
             "custom": "Custom (OpenAI-compatible)"
         },
         "defaultModel": "Default Model",

--- a/apps/web/src/locales/ko.json
+++ b/apps/web/src/locales/ko.json
@@ -1040,6 +1040,7 @@
             "anthropic": "Anthropic",
             "google": "Google",
             "ollama": "Ollama (로컬)",
+            "qiniu": "Qiniu",
             "custom": "사용자 지정 (OpenAI 호환)"
         },
         "defaultModel": "기본 모델",

--- a/apps/web/src/locales/pt.json
+++ b/apps/web/src/locales/pt.json
@@ -1040,6 +1040,7 @@
             "anthropic": "Anthropic",
             "google": "Google",
             "ollama": "Ollama (Local)",
+            "qiniu": "Qiniu",
             "custom": "Personalizado (Compatível com OpenAI)"
         },
         "defaultModel": "Modelo Padrão",

--- a/apps/web/src/locales/ru.json
+++ b/apps/web/src/locales/ru.json
@@ -1040,6 +1040,7 @@
             "anthropic": "Anthropic",
             "google": "Google",
             "ollama": "Ollama (Local)",
+            "qiniu": "Qiniu",
             "custom": "Custom (OpenAI-compatible)"
         },
         "defaultModel": "Default Model",

--- a/apps/web/src/locales/zh.json
+++ b/apps/web/src/locales/zh.json
@@ -1040,6 +1040,7 @@
             "anthropic": "Anthropic",
             "google": "Google",
             "ollama": "Ollama (Local)",
+            "qiniu": "Qiniu",
             "custom": "Custom (OpenAI-compatible)"
         },
         "defaultModel": "Default Model",

--- a/apps/web/telegram-bot.js
+++ b/apps/web/telegram-bot.js
@@ -491,7 +491,8 @@ async function sendProviderMenu(token, chatId) {
         ['openrouter', 'OpenRouter'], ['openai', 'OpenAI'],
         ['anthropic', 'Anthropic'],   ['google', 'Google'],
         ['groq', 'Groq'],             ['mistral', 'Mistral'],
-        ['deepseek', 'DeepSeek'],     ['ollama', 'Ollama'],
+        ['deepseek', 'DeepSeek'],     ['qiniu', 'Qiniu'],
+        ['ollama', 'Ollama'],
     ];
 
     const rows = [];


### PR DESCRIPTION
## Summary
Added support for Qiniu AI (七牛云) as a new model provider.

## What changed

- `apps/web/src/actions/autopilot.ts` - Updates autopilot action flow for provider integration behavior.
- `apps/web/src/actions/capabilities.ts` - Extends capability action handling for new provider support.
- `apps/web/src/actions/chat.ts` - Adjusts chat action logic to route Qiniu-related requests.
- `apps/web/src/actions/code-builder.ts` - Updates code builder action path to support provider-specific behavior.
- `apps/web/src/actions/orchestrator.ts` - Refines orchestrator action coordination for multi-provider execution.
- `apps/web/src/app/agents/page.tsx` - Updates agents UI page to surface provider configuration changes.
- `apps/web/src/app/bootstrap/page.tsx` - Adjusts bootstrap UI flow for updated provider setup.
- `apps/web/src/app/custom-skills/page.tsx` - Updates custom skills page behavior impacted by provider changes.
- `apps/web/src/app/group-chat/settings/page.tsx` - Updates group chat settings UI for provider-related options.
- `apps/web/src/app/settings/page.tsx` - Extends global settings page for new provider support.
- `apps/web/src/data/builtin-skills/quoty.js` - Updates builtin skill data used in provider-aware workflows.
- `apps/web/src/lib/autonomous-runner.ts` - Refines autonomous runner logic to handle provider dispatch updates.
- `apps/web/src/lib/skill-ai.ts` - Updates AI skill execution layer for Qiniu provider compatibility.
- `apps/web/src/lib/skill-dispatcher.ts` - Enhances skill dispatcher routing across provider-specific branches.
- `apps/web/telegram-bot.js` - Updates Telegram bot behavior to align with provider integration changes.

## Result
<img width="2028" height="1236" alt="屏幕截图 2026-05-12 101818" src="https://github.com/user-attachments/assets/a7a2a98c-7402-448e-b9fb-16b87e4dbaff" />

---

<img width="1978" height="807" alt="屏幕截图 2026-05-12 101839" src="https://github.com/user-attachments/assets/b7a0d7d2-ff23-4fe7-ad25-9a451d96506e" />
